### PR TITLE
fix: Missing null check

### DIFF
--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -70,7 +70,7 @@ class FlutterCallkeep extends EventManager {
   Future<void> _hasDefaultPhoneAccount(Map<String, dynamic> options) async {
     final hasDefault = await _checkDefaultPhoneAccount();
     final shouldOpenAccounts = await _alert(options, hasDefault);
-    if (shouldOpenAccounts) {
+    if (shouldOpenAccounts == true) {
       await _openPhoneAccounts();
     }
   }


### PR DESCRIPTION
Hey :-)

first of all, thank you for your awesome package. We have implemented it in our app. Our sentry error tracking has found a missing null check. The `shouldOpenAccounts` boolean can be null if the user dismisses the dialog by clicking on the background. This should fix this :)

Best regards and stay healthy