### PR TITLE
hasDefaultPhoneAccount give feedback about the user choice

### DIFF
--- a/ios/Classes/CallKeep.m
+++ b/ios/Classes/CallKeep.m
@@ -88,7 +88,7 @@ static CXProvider* sharedProvider;
         result(nil);
     }
     else if ([@ "startCall" isEqualToString:method]) {
-        [self startCall:argsMap[@"uuid"] handle:argsMap[@"handle"] contactIdentifier:argsMap[@"callerName"] handleType:argsMap[@"handleType"] video:[argsMap[@"hasVideo"] boolValue]];
+        [self startCall:argsMap[@"uuid"] handle:argsMap[@"number"] contactIdentifier:argsMap[@"callerName"] handleType:argsMap[@"handleType"] video:[argsMap[@"hasVideo"] boolValue]];
         result(nil);
     }
     else if ([@"isCallActive" isEqualToString:method]) {

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -53,13 +53,15 @@ class FlutterCallkeep extends EventManager {
     return _channel.invokeMethod<void>('registerEvents', <String, dynamic>{});
   }
 
-  Future<void> hasDefaultPhoneAccount(
+  Future<bool> hasDefaultPhoneAccount(
       BuildContext context, Map<String, dynamic> options) async {
     _context = context;
     if (!isIOS) {
-      return _hasDefaultPhoneAccount(options);
+      return await _hasDefaultPhoneAccount(options);
     }
-    return;
+
+    // return true on iOS because we don't want to block the endUser
+    return true;
   }
 
   Future<bool> _checkDefaultPhoneAccount() async {
@@ -67,12 +69,14 @@ class FlutterCallkeep extends EventManager {
         .invokeMethod<bool>('checkDefaultPhoneAccount', <String, dynamic>{});
   }
 
-  Future<void> _hasDefaultPhoneAccount(Map<String, dynamic> options) async {
+  Future<bool> _hasDefaultPhoneAccount(Map<String, dynamic> options) async {
     final hasDefault = await _checkDefaultPhoneAccount();
     final shouldOpenAccounts = await _alert(options, hasDefault);
-    if (shouldOpenAccounts == true) {
+    if (shouldOpenAccounts) {
       await _openPhoneAccounts();
+      return true;
     }
+    return false;
   }
 
   Future<void> displayIncomingCall(String uuid, String handle,

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -104,19 +104,19 @@ class FlutterCallkeep extends EventManager {
     }
   }
 
-  Future<void> startCall(String uuid, String handle, String callerName,
+  Future<void> startCall(String uuid, String number, String callerName,
       {String handleType = 'number', bool hasVideo = false}) async {
     if (!isIOS) {
       await _channel.invokeMethod<void>('startCall', <String, dynamic>{
         'uuid': uuid,
-        'handle': handle,
+        'number': number,
         'callerName': callerName
       });
       return;
     }
     await _channel.invokeMethod<void>('startCall', <String, dynamic>{
       'uuid': uuid,
-      'handle': handle,
+      'number': number,
       'callerName': callerName,
       'handleType': handleType,
       'hasVideo': hasVideo


### PR DESCRIPTION
Now we can use hasDefaultPhoneAccount that way 

```dart
callKeep.hasDefaultPhoneAccount(context, <String, dynamic>{
        'alertTitle': 'Permissions required',
        'alertDescription':
            'This application needs to access your phone accounts',
        'cancelButton': 'Cancel',
        'okButton': 'ok',
}).then((userHasTapedOk) {
// we can handle the case when the user refuse to give his permission
});
```

This will be usefull