### PR TITLE
[FIX] Duplicated call onAnswer. New open method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ final callSetup = <String, dynamic>{
       'channelId': 'com.company.my',
       'channelName': 'Foreground service for my app',
       'notificationTitle': 'My app is running on background',
-      'notificationIcon': 'Path to the resource icon of the notification',
+      'notificationIcon': 'mipmap/ic_notification_launcher',
     }, 
   },
 };

--- a/android/src/main/java/com/github/cloudwebrtc/flutter_callkeep/FlutterCallkeepPlugin.java
+++ b/android/src/main/java/com/github/cloudwebrtc/flutter_callkeep/FlutterCallkeepPlugin.java
@@ -66,7 +66,7 @@ public class FlutterCallkeepPlugin implements FlutterPlugin, MethodCallHandler, 
 
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    if (!callKeep.HandleMethodCall(call, result)) {
+    if (!callKeep.handleMethodCall(call, result)) {
       result.notImplemented();
     }
   }

--- a/android/src/main/java/io/wazo/callkeep/CallKeepModule.java
+++ b/android/src/main/java/io/wazo/callkeep/CallKeepModule.java
@@ -97,11 +97,13 @@ public class CallKeepModule {
     }
 
     public void dispose(){
+        if (voiceBroadcastReceiver == null || this._context == null) return;
         LocalBroadcastManager.getInstance(this._context).unregisterReceiver(voiceBroadcastReceiver);
         VoiceConnectionService.setPhoneAccountHandle(null);
+        isReceiverRegistered = false;
     }
 
-    public boolean HandleMethodCall(@NonNull MethodCall call, @NonNull Result result) {
+    public boolean handleMethodCall(@NonNull MethodCall call, @NonNull Result result) {
         switch(call.method) {
             case "setup": {
                 setup(new ConstraintsMap((Map<String, Object>)call.argument("options")));
@@ -219,6 +221,9 @@ public class CallKeepModule {
     }
     
     public void setup(ConstraintsMap options) {
+        if (isReceiverRegistered) {
+            return;
+        }
         VoiceConnectionService.setAvailable(false);
         this._settings = options;
         if (isConnectionServiceAvailable()) {
@@ -243,7 +248,6 @@ public class CallKeepModule {
         if (!isConnectionServiceAvailable()) {
             return;
         }
-
         voiceBroadcastReceiver = new VoiceBroadcastReceiver();
         registerReceiver();
         VoiceConnectionService.setPhoneAccountHandle(handle);

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -83,27 +83,20 @@ public class VoiceConnection extends Connection {
     public void onAnswer() {
         super.onAnswer();
         Log.d(TAG, "onAnswer called");
-
-        setConnectionCapabilities(getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
-        setAudioModeIsVoip(true);
-
-        sendCallRequestToActivity(ACTION_ANSWER_CALL, handle);
-        sendCallRequestToActivity(ACTION_AUDIO_SESSION, handle);
-        Log.d(TAG, "onAnswer executed");
+        Log.d(TAG, "onAnswer ignored");
     }
-    
     
     @Override
     public void onAnswer(int videoState) {
         super.onAnswer(videoState);
-        Log.d(TAG, "onAnswer called");
+        Log.d(TAG, "onAnswer videoState called: " + videoState);
 
         setConnectionCapabilities(getConnectionCapabilities() | Connection.CAPABILITY_HOLD);
         setAudioModeIsVoip(true);
 
         sendCallRequestToActivity(ACTION_ANSWER_CALL, handle);
         sendCallRequestToActivity(ACTION_AUDIO_SESSION, handle);
-        Log.d(TAG, "onAnswer executed");
+        Log.d(TAG, "onAnswer videoState executed");
     }
 
     @Override

--- a/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnectionService.java
@@ -229,7 +229,17 @@ public class VoiceConnectionService extends ConnectionService {
             Context context = this.getApplicationContext();
             Resources res = context.getResources();
             String smallIcon = foregroundSettings.getString("notificationIcon");
-            notificationBuilder.setSmallIcon(res.getIdentifier(smallIcon, "mipmap", context.getPackageName()));
+            String mipmap = "mipmap/";
+            String drawable = "drawable/";
+            if (smallIcon.contains(mipmap)) {
+                notificationBuilder.setSmallIcon(
+                        res.getIdentifier(smallIcon.replace(mipmap, ""),
+                                "mipmap", context.getPackageName()));
+            } else if (smallIcon.contains(drawable)) {
+                notificationBuilder.setSmallIcon(
+                        res.getIdentifier(smallIcon.replace(drawable, ""),
+                                "drawable", context.getPackageName()));
+            }
         }
 
         Log.d(TAG, "[VoiceConnectionService] Starting foreground service");

--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -310,6 +310,10 @@ class FlutterCallkeep extends EventManager {
     return false;
   }
 
+  Future<void> openPhoneAccounts() async {
+    _openPhoneAccounts();
+  }
+
   Future<void> _openPhoneAccounts() async {
     if (!Platform.isAndroid) {
       return;


### PR DESCRIPTION
- Allows more flexible workflows for managing phone accounts without alerts.
- Fixes duplicated call of `onAnswer`.
```
// always is called
void onAnswer(int videoState)
// and after:
void onAnswer() <-- now this is ignored
```
But the `void onAnswer(int videoState)` method (in `VoiceConnection`) stills being invoked twice. Before this change, `CallKeepPerformAnswerCallAction` was called x4.
- Added support for `drawable` icons for the foreground service's notification:
```
'drawable/ic_notification_launcher'
'mipmap/ic_notification_launcher'
```
- Readme updated