### PR TITLE
fix: null value cannot be cast to List<String> directly

### DIFF
--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -306,8 +306,9 @@ class FlutterCallkeep extends EventManager {
       return true;
     }
 
+    final additionalPermissions = options['additionalPermissions'] ?? [];
     final showAccountAlert = await _checkPhoneAccountPermission(
-        options['additionalPermissions'] as List<String>);
+        additionalPermissions.cast<String>() as List<String>);
     final shouldOpenAccounts = await _alert(options, showAccountAlert);
 
     if (shouldOpenAccounts) {


### PR DESCRIPTION
Hi. 
I am using the example code to create a test project.
According to the example, the following is passed to the setup method,

```
      'ios': {
        'appName': 'CallKeepDemo',
      },
      'android': {
        'alertTitle': 'Permissions required',
        'alertDescription':
            'This application needs to access your phone accounts',
        'cancelButton': 'Cancel',
        'okButton': 'ok',
        'foregroundService': {
          'channelId': 'com.quando.synq.development',
          'channelName': 'Foreground service for my app',
          'notificationTitle': 'My app is running on background',
          'notificationIcon': 'Path to the resource icon of the notification',
        },
      },
```

If `additionalPermissions` parameter is not exist, I got a runtime error like the following:

> package:callkeep/src/api.dart
> type 'Null' is not a subtype of type 'List<String>' in type cast

I tried to fix it once, but I'm not sure if I'm using it wrong in the first place, 
or if you have any good advice, please let me know 🙇 

## Environments
- Flutter: 2.5.3-stable
- Android Emulator:
  - Pixel 4 
  - Android 11.0 (Google Play)
  - API 30
  - arm64