### PR TITLE
Make the Object nullable in Android activeCalls

### DIFF
--- a/lib/src/api.dart
+++ b/lib/src/api.dart
@@ -210,7 +210,7 @@ class FlutterCallkeep extends EventManager {
 
   Future<List<String>> activeCalls() async {
     var resp = await _channel
-        .invokeMethod<List<Object>?>('activeCalls', <String, dynamic>{});
+        .invokeMethod<List<Object?>?>('activeCalls', <String, dynamic>{});
     if (resp != null) {
       var uuids = <String>[];
       resp.forEach((element) {


### PR DESCRIPTION
In at least some cases when using the activeCalls function you'll receive the error:

type 'List<Object?>' is not a subtype of type 'List<Object'>?' in type cast     <--there's an extra ' or the word Object disappears

This makes the Object nullable to deal with that.