### PR TITLE
Extracting UI responsibility, named parameters, android dismissal fix

### DIFF
--- a/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
+++ b/android/src/main/java/io/wazo/callkeep/VoiceConnection.java
@@ -154,6 +154,7 @@ public class VoiceConnection extends Connection {
 
     private void onAnswered() {
         initCall();
+        setCurrent();
         sendCallRequestToActivity(ACTION_ANSWER_CALL, connectionData);
     }
 

--- a/ios/Classes/CallKeep.m
+++ b/ios/Classes/CallKeep.m
@@ -212,7 +212,6 @@ static NSObject<CallKeepPushDelegate>* _delegate;
 - (NSString *)createUUID {
     CFUUIDRef uuidObject = CFUUIDCreate(kCFAllocatorDefault);
     NSString *uuidStr = (NSString *)CFBridgingRelease(CFUUIDCreateString(kCFAllocatorDefault, uuidObject));
-    CFUUIDBytes bytes = CFUUIDGetUUIDBytes(uuidObject);
     CFRelease(uuidObject);
     return [uuidStr lowercaseString];
 }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -77,14 +77,11 @@ class EventManager {
     });
   }
 
-  void remove<T extends EventType>(T eventType, ValueChanged<T> listener) {
-    final targets = listeners[eventType.runtimeType];
-    if (targets == null) {
-      return;
-    }
-    //    logger.warn("removing $eventType on $listener");
+  void remove<T extends EventType>(ValueChanged<T> listener) {
+    final targets = listeners[T];
+    if (targets == null) return;
     if (!targets.remove(listener)) {
-      logger.d('Failed to remove any listeners for EventType $eventType');
+      logger.d('Failed to remove any listeners for EventType $T');
     }
   }
 


### PR DESCRIPTION
Three main fixes:

Android calling UI wasn't being dismissed when answerIncomingCall() was being called from in app UI. 
needed to call setCurrent() in native android.

I spent ages trying to figure out why things weren't working only to realise i was passing the caller name into the handle parameter. Added named parameters to all functions so that shouldnt happen for anyone in the future and things are clearer.

In recent versions of flutter the framekwork suggest against passing BuildContexts across async gaps also your app should be responsible for how it looks not an external package. For the default permissions UI i've extracted out the responsibility so the app using the package can determine how that dialog looks.

Also some updates to the readme!