### PR TITLE
upgrade compileSdkVersion to 31 to avoid build release failed in android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 23


### PR DESCRIPTION
When build release version in android device using `flutter run --release`, the latest version of package will result in error 
```
AAPT: error: resource android:attr/lStar not found.
```

Its because of the compileSdkVersion is too low, so some resource is missing, upgrade to at least 31 will solve the problem.