### PR TITLE
Fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Future<void> closeIncomingCall(
 
 Pass in your own dialog UI for permissions alerts:
 
-````dart
+```dart
 showAlertDialog: () async {
         final BuildContext context = navigatorKey.currentContext!;
 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Future<void> closeIncomingCall(
 }
 ```
 
-Pass in your own dialog UI for permissions alerts
+Pass in your own dialog UI for permissions alerts:
 
 ````dart
 showAlertDialog: () async {

--- a/README.md
+++ b/README.md
@@ -264,7 +264,8 @@ showAlertDialog: () async {
               },
             ) ??
             false;
-      }
+      },
+
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ showAlertDialog: () async {
               },
             ) ??
             false;
-      },
+      }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,6 @@ showAlertDialog: () async {
             ) ??
             false;
       },
-
 ```
 
 
@@ -285,4 +284,3 @@ Even in this scenario, the `backToForeground()` method will open the app and you
 ## push test tool
 
 Please refer to the [Push Toolkit](/tools/) to test callkeep offline push.
-````


### PR DESCRIPTION
That last code block was using quad backticks, fixed.